### PR TITLE
refactor: Roboto font, no gradient text, single-frame AppPreview

### DIFF
--- a/components/AiUseCase.tsx
+++ b/components/AiUseCase.tsx
@@ -44,7 +44,7 @@ export default function AiUseCase() {
         </span>
         <h2
           id="ai-usecase-heading"
-          className="font-fraunces text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900"
+          className="font-roboto text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900"
         >
           Authorization your AI can&apos;t talk its way around
         </h2>

--- a/components/AppPreview.tsx
+++ b/components/AppPreview.tsx
@@ -1,21 +1,7 @@
-import { useState, type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { Authorizer, useAuthorizer } from '@authorizerdev/authorizer-react';
 
-type Tab = {
-  id: string;
-  label: string;
-  url: string;
-  appName: string;
-};
-
-const TABS: Tab[] = [
-  { id: 'saas',       label: 'SaaS App',     url: 'your-saas.com/login',        appName: 'Acme Corp'   },
-  { id: 'devtool',    label: 'Dev Tool',      url: 'console.devtool.io/login',   appName: 'DevConsole'  },
-  { id: 'ecommerce',  label: 'E-commerce',    url: 'shop.example.com/account',   appName: 'ShopNow'     },
-  { id: 'ai',         label: 'AI Product',    url: 'ai-assistant.app/login',     appName: 'AiAssist'    },
-];
-
-function BrowserFrame({ tab, children }: { tab: Tab; children: ReactNode }) {
+function BrowserFrame({ url, appName, children }: { url: string; appName: string; children: ReactNode }) {
   return (
     <div className='rounded-2xl border border-gray-200 overflow-hidden shadow-xl bg-white'>
       {/* Browser chrome */}
@@ -26,15 +12,15 @@ function BrowserFrame({ tab, children }: { tab: Tab; children: ReactNode }) {
           <span className='w-3 h-3 rounded-full bg-green-400' />
         </div>
         <div className='flex-1 bg-white rounded-md px-3 py-1 text-xs text-gray-400 border border-gray-200 font-mono truncate'>
-          {tab.url}
+          {url}
         </div>
       </div>
 
       {/* Mock app shell */}
-      <div className='bg-gray-50 min-h-[520px] flex flex-col'>
+      <div className='bg-gray-50 min-h-[480px] flex flex-col'>
         {/* App nav */}
         <nav className='bg-white border-b border-gray-100 px-6 py-3 flex items-center justify-between'>
-          <span className='font-semibold text-gray-800 text-sm'>{tab.appName}</span>
+          <span className='font-semibold text-gray-800 text-sm'>{appName}</span>
           <div className='hidden sm:flex items-center gap-4 text-xs text-gray-500'>
             <span>Home</span>
             <span>Features</span>
@@ -53,50 +39,28 @@ function BrowserFrame({ tab, children }: { tab: Tab; children: ReactNode }) {
 
 export default function AppPreview() {
   const { user, logout, loading } = useAuthorizer();
-  const [activeTab, setActiveTab] = useState<string>('saas');
-  const current = TABS.find((t) => t.id === activeTab) ?? TABS[0];
 
   return (
-    <section className='container mx-auto max-w-7xl my-20 px-4 md:px-0'>
+    <section className='container mx-auto max-w-5xl my-20 px-4 md:px-0'>
       <div className='text-center mb-10'>
         <span className='inline-block text-xs font-semibold tracking-widest uppercase text-blue-600 bg-blue-50 rounded-full px-3 py-1 mb-4'>
           See it in your app
         </span>
         <h2 className='text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900'>
           Fits any product,{' '}
-          <span className='text-transparent bg-clip-text bg-gradient-to-br from-blue-600 to-pink-400'>
-            out of the box
-          </span>
+          <span className='text-blue-600'>out of the box</span>
         </h2>
         <p className='mt-4 text-lg text-gray-600 max-w-2xl mx-auto'>
-          Drop the Authorizer component into any app — the login experience adapts to your brand. Try it live below.
+          Drop the Authorizer component into any app — SaaS, dev tool, e-commerce, AI product. The same login experience, always under your control.
         </p>
       </div>
 
-      {/* Tab strip */}
-      <div className='flex overflow-x-auto gap-2 pb-1 mb-8 scrollbar-none'>
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            type='button'
-            onClick={() => setActiveTab(tab.id)}
-            className={`shrink-0 px-5 py-2 rounded-full text-sm font-medium transition-colors duration-150 ${
-              activeTab === tab.id
-                ? 'bg-blue-600 text-white shadow-sm'
-                : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {/* Browser frame with live Authorizer widget */}
-      <BrowserFrame tab={current}>
+      {/* Single browser frame */}
+      <BrowserFrame url='your-app.com/login' appName='Your App'>
         {loading ? (
           <div className='text-sm text-gray-400'>Loading…</div>
         ) : user ? (
-          <div className='w-full max-w-sm mx-auto bg-white rounded-xl border border-gray-200 shadow-lg p-8 text-center'>
+          <div className='w-full max-w-xs mx-auto bg-white rounded-xl border border-gray-200 shadow-lg p-8 text-center'>
             <p className='text-gray-500 text-sm mb-1'>Signed in as</p>
             <p className='font-semibold text-gray-900'>{user.email}</p>
             <button
@@ -108,7 +72,7 @@ export default function AppPreview() {
             </button>
           </div>
         ) : (
-          <div className='w-full max-w-sm mx-auto authorizer-demo'>
+          <div className='w-full max-w-xs mx-auto authorizer-demo'>
             <Authorizer />
           </div>
         )}

--- a/components/CompareAlternatives.tsx
+++ b/components/CompareAlternatives.tsx
@@ -66,7 +66,7 @@ export default function CompareAlternatives() {
       <div className="text-center mb-12">
         <h2
           id="compare-heading"
-          className="font-fraunces text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900"
+          className="font-roboto text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900"
         >
           Authorizer vs hosted identity platforms
         </h2>

--- a/components/Database.tsx
+++ b/components/Database.tsx
@@ -72,7 +72,7 @@ export default function Database() {
   return (
     <div className="bg-slate-50 my-20">
       <div className="container mx-auto max-w-7xl py-16 px-10">
-        <h2 className="font-fraunces text-3xl sm:text-4xl font-semibold tracking-tight text-center text-gray-900">
+        <h2 className="font-roboto text-3xl sm:text-4xl font-semibold tracking-tight text-center text-gray-900">
           Bring your own database
         </h2>
         <p className="mt-4 text-center text-lg text-gray-600 max-w-2xl mx-auto">

--- a/components/DeveloperApi.tsx
+++ b/components/DeveloperApi.tsx
@@ -55,7 +55,7 @@ export default function DeveloperApi() {
         <div className="text-center mb-12">
           <h2
             id="developer-api-heading"
-            className="font-fraunces text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900"
+            className="font-roboto text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900"
           >
             Three protocols. SDKs for every stack.
           </h2>

--- a/components/Features.tsx
+++ b/components/Features.tsx
@@ -126,9 +126,9 @@ export default function Features() {
 				<span className="inline-block text-xs font-semibold tracking-widest uppercase text-blue-600 bg-blue-50 rounded-full px-3 py-1 mb-4">
 					Everything you need
 				</span>
-				<h2 className="font-fraunces text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900">
+				<h2 className="font-roboto text-3xl sm:text-4xl font-semibold tracking-tight text-gray-900">
 					The hardest part of app development,{' '}
-					<span className="text-transparent bg-clip-text bg-gradient-to-br from-blue-600 to-pink-400">
+					<span className="text-blue-600">
 						made simple
 					</span>
 				</h2>

--- a/components/GettingStarted.tsx
+++ b/components/GettingStarted.tsx
@@ -53,7 +53,7 @@ export default function GettingStarted() {
         <div className="flex flex-wrap -mx-8">
           <div className="w-full lg:w-1/2 px-8">
             <div className="mb-12 lg:mb-0 pb-12 lg:pb-0 border-b lg:border-b-0">
-              <h2 className="mb-2 font-fraunces text-3xl font-semibold">
+              <h2 className="mb-2 font-roboto text-3xl font-semibold">
                 Get started in{" "}
                 <span className="font-extrabold text-blue-500">
                   3 simple steps

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -79,7 +79,7 @@ export default function Hero({ stars = 0 }: { stars?: number }) {
             Cloud-native · Open source · Apache-2.0
           </span>
 
-          <h1 className='mt-6 font-fraunces font-extrabold text-[44px] leading-[50px] md:text-[60px] md:leading-[66px] text-gray-900'>
+          <h1 className='mt-6 font-roboto font-extrabold text-[44px] leading-[50px] md:text-[60px] md:leading-[66px] text-gray-900'>
             Own your{' '}
             <span className='text-blue-600'>identity</span>{' '}
             layer

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { Fraunces } from 'next/font/google';
+import { Roboto } from 'next/font/google';
 import Nav from "./Nav";
 import Footer from "./Footer";
 import SeoJsonLd from "./SeoJsonLd";
@@ -14,9 +14,10 @@ import {
   TWITTER_CARD_IMAGE_URL,
 } from "../constants/site";
 
-const fraunces = Fraunces({
+const roboto = Roboto({
+  weight: ["400", "500", "700", "900"],
   subsets: ['latin'],
-  variable: '--font-fraunces',
+  variable: '--font-roboto',
   display: 'swap',
 });
 
@@ -142,7 +143,7 @@ export default function Layout({ children }) {
           zIndex: 100,
         }}
       />
-      <div className={`min-h-screen ${fraunces.variable}`}>
+      <div className={`min-h-screen ${roboto.variable}`}>
         <Nav />
         <main className="pt-10">{children}</main>
         <Footer />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
 		},
 		extend: {
 			fontFamily: {
-				fraunces: ['var(--font-fraunces)', 'Georgia', 'serif'],
+				roboto: ['var(--font-roboto)', 'sans-serif'],
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

- Replaced Fraunces serif with Roboto across all components (Layout, Hero, Features, AiUseCase, CompareAlternatives, DeveloperApi, Database, GettingStarted)
- Removed all gradient text (`text-transparent bg-clip-text`) site-wide; replaced with solid `text-blue-600` accents
- Redesigned AppPreview: removed 4-tab strip, now shows a single centered browser frame with a narrower login container (`max-w-xs`), copy updated to explain it applies to any product type

## Test plan

- [ ] Build passes (`npm run build`) — verified locally
- [ ] No gradient text visible on any section heading
- [ ] All headings use Roboto (sans-serif)
- [ ] AppPreview shows single browser frame with centered login widget
- [ ] Live Authorizer widget renders and functions correctly